### PR TITLE
s390x.risu: Add basic subtractions

### DIFF
--- a/s390x.risu
+++ b/s390x.risu
@@ -43,6 +43,23 @@ ALGR Z 10111001 00001010 00000000 r1:4 r2:4
 # format:RRE Add Logical (32 bit to 64 bit)
 ALGFR Z 10111001 00011010 00000000 r1:4 r2:4
 
+# format:RR Subtract (register + register, 32 bit)
+SR Z 00011011 r1:4 r2:4
+
+# format:RRE Subtract (register + register, 64 bit)
+SGR Z 10111001 00001001 00000000 r1:4 r2:4
+
+# format:RRE Subtract (register + register, 32 bit to 64 bit)
+SGFR Z 10111001 00011001 00000000 r1:4 r2:4
+
+# format:RR Subtract Logical (32 bit)
+SLR Z 00011111 r1:4 r2:4
+
+# format:RRE Subtract Logical (64 bit)
+SLGR Z 10111001 00001011 00000000 r1:4 r2:4
+
+# format:RRE Subtract Logical (32 bit to 64 bit)
+SLGFR Z 10111001 00011011 00000000 r1:4 r2:4
 
 # format:RRF-c Population Count
 POPCNT STFLE45 10111001 11100001 m3:4 0000 r1:4 r2:4


### PR DESCRIPTION
Add subtraction operations that don't involve storage. Don't add borrow instruction because unsure yet how to handle PWD manipulation.